### PR TITLE
Fix broken action

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:stable-20210408-slim AS BUILDER
+FROM debian:stable-slim AS BUILDER
 ENV LANG=C.UTF-8 \
     LC_ALL=C.UTF-8 \
     TERM=dumb
@@ -9,7 +9,7 @@ RUN git clone --depth=1 https://github.com/johnwhitington/cpdfsqueeze.git
 WORKDIR /tmp/cpdfsqueeze
 RUN make
 
-FROM debian:stable-20210408-slim
+FROM debian:stable-slim
 COPY --from=builder /tmp/cpdfsqueeze/cpdfsqueeze /usr/bin
 COPY entrypoint.sh /entrypoint.sh
 RUN mkdir /workdir


### PR DESCRIPTION
When running the latest branch of this action, the configured container tries to access an apt repository which no longer exists. Proposal is to change the container to the latest slim tag. Alternatively one could update the tag to a stable but more recent tag.